### PR TITLE
Added compat for mods that change CC + version fix (for SMAPI)

### DIFF
--- a/content.json
+++ b/content.json
@@ -27,6 +27,11 @@
 			"Default": "Lakeside",
 			"Section": "Map Patches",
 		},
+		"CommunityCenter_Elevator": {
+			"AllowValues": "AutoDetect, Left, Right",
+			"Default": "AutoDetect",
+			"Section": "Map Patches",
+		},
 		"Case_Countdown": {
 			"AllowValues": "1, 7, 14, 21, 28",
 			"Default": 7,
@@ -293,6 +298,20 @@
 			"FromFile": "data/Compat/FinchHouseAlternate.json",
 			"When": {
 				"FinchHouse_Location": "MountainPass",
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "data/Compat/CommunityCenterElevatorAlt.json",
+			"When": { // compat
+				"Query: ({{CommunityCenter_Elevator |contains=AutoDetect}} AND {{HasMod |contains=Lnh.CommunityCenterExpanded}}) OR {{CommunityCenter_Elevator |contains=Left}}": true,
+			}
+		},
+		{
+			"Action": "Include",
+			"FromFile": "data/Compat/CommunityCenterElevator.json",
+			"When": { // default
+				"Query: ({{CommunityCenter_Elevator |contains=AutoDetect}} AND NOT {{HasMod |contains=Lnh.CommunityCenterExpanded}}) OR {{CommunityCenter_Elevator |contains=Right}}": true,
 			}
 		},
     ],

--- a/data/Compat/CommunityCenterElevator.json
+++ b/data/Compat/CommunityCenterElevator.json
@@ -1,0 +1,29 @@
+{
+    "Changes": [			
+		//  VANILLA MAP PATCHES
+			// CC normal
+		{
+			"Action": "EditMap",
+			"Target": "Maps/CommunityCenter_Ruins",
+			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
+			"FromArea": { "X": 0, "Y": 0, "Width": 7, "Height": 6 },
+			"ToArea": { "X": 45, "Y": 14, "Width": 7, "Height": 6 },
+		},
+			// CC post-completion
+		{
+			"Action": "EditMap",
+			"Target": "Maps/CommunityCenter_Refurbished",
+			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
+			"FromArea": { "X": 0, "Y": 0, "Width": 7, "Height": 6 },
+			"ToArea": { "X": 45, "Y": 14, "Width": 7, "Height": 6 },
+		},
+			// CC joja route
+		{
+			"Action": "EditMap",
+			"Target": "Maps/CommunityCenter_Joja",
+			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
+			"FromArea": { "X": 0, "Y": 0, "Width": 7, "Height": 6 },
+			"ToArea": { "X": 45, "Y": 14, "Width": 7, "Height": 6 },
+		},
+	]
+}

--- a/data/Compat/CommunityCenterElevatorAlt.json
+++ b/data/Compat/CommunityCenterElevatorAlt.json
@@ -1,0 +1,67 @@
+{
+    "Changes": [
+		// COMPAT
+			// CC normal
+		{
+			"Action": "EditMap",
+			"Target": "Maps/CommunityCenter_Ruins",
+			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
+			"PatchMode": "ReplaceByLayer",
+			"FromArea": { "X": 0, "Y": 1, "Width": 7, "Height": 5 },
+			"ToArea": { "X": 0, "Y": 14, "Width": 7, "Height": 5 },
+		},
+			// CC post-completion
+		{
+			"Action": "EditMap",
+			"Target": "Maps/CommunityCenter_Refurbished",
+			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
+			"PatchMode": "ReplaceByLayer",
+			"FromArea": { "X": 0, "Y": 1, "Width": 7, "Height": 5 },
+			"ToArea": { "X": 0, "Y": 14, "Width": 7, "Height": 5 },
+		},
+			// CC joja route
+		{
+			"Action": "EditMap",
+			"Target": "Maps/CommunityCenter_Joja",
+			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
+			"PatchMode": "ReplaceByLayer",
+			"FromArea": { "X": 0, "Y": 1, "Width": 7, "Height": 5 },
+			"ToArea": { "X": 0, "Y": 14, "Width": 7, "Height": 5 },
+		},
+			// Unborking of tiles at top of area
+		{
+			"Action": "EditMap",
+			"Target":"Maps/CommunityCenter_Ruins, Maps/CommunityCenter_Refurbished, Maps/CommunityCenter_Joja",
+			"MapTiles": [
+				{
+					"Position":{"X": 0, "Y": 13},
+					"Layer": "Front",
+					"SetIndex": "64"
+				},
+				{
+					"Position":{"X": 1, "Y": 13},
+					"Layer": "Front",
+					"SetIndex": "1286"
+				},
+				{
+					"Position":{"X": 2, "Y": 13},
+					"Layer": "Front",
+					"SetIndex": "1286"
+				},
+				{
+					"Position":{"X": 3, "Y": 13},
+					"Layer": "Front",
+					"SetIndex": "163"
+				}
+			]
+		},
+			// Fixes warp DeadBoyAgency -> CommunityCenter
+		{
+			"Action": "EditMap",
+			"Target":"Maps/{{ModId}}_DeadBoyAgency",
+            "AddWarps": [
+                "6 20 CommunityCenter 5 17"
+            ]
+		},
+	]
+}

--- a/data/Maps.json
+++ b/data/Maps.json
@@ -224,30 +224,6 @@
 		},
 			
 		//  VANILLA MAP PATCHES
-			// CC normal
-		{
-			"Action": "EditMap",
-			"Target": "Maps/CommunityCenter_Ruins",
-			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
-			"FromArea": { "X": 0, "Y": 0, "Width": 7, "Height": 6 },
-			"ToArea": { "X": 45, "Y": 14, "Width": 7, "Height": 6 }
-		},
-			// CC post-completion
-		{
-			"Action": "EditMap",
-			"Target": "Maps/CommunityCenter_Refurbished",
-			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
-			"FromArea": { "X": 0, "Y": 0, "Width": 7, "Height": 6 },
-			"ToArea": { "X": 45, "Y": 14, "Width": 7, "Height": 6 }
-		},
-			// CC joja route
-		{
-			"Action": "EditMap",
-			"Target": "Maps/CommunityCenter_Joja",
-			"FromFile": "assets/maps/CommunityCenter_RuinsRedux.tmx",
-			"FromArea": { "X": 0, "Y": 0, "Width": 7, "Height": 6 },
-			"ToArea": { "X": 45, "Y": 14, "Width": 7, "Height": 6 }
-		},
 			// entrance to lighthouse beach
 		{
 			"Action": "EditMap",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "Dead Boy Detectives",
     "Author": "handwrittenhello",
-    "Version": "2.0.0_beta",
+    "Version": "2.0.0-beta",
     "Description": "An expansion exploring the supernatural side of Pelican Town, with ghosts, shapeshifters, and more.",
     "UniqueID": "handwrittenhello.dbda",
     "UpdateKeys": [ "Nexus:31888" ],


### PR DESCRIPTION
- Fixed version in `manifest.json` to adhere to semantic version so SMAPI stops shouting
- Added compat for mods that change the Community Center
    - Moved CC edits to own files in `data/Maps`
    - Added config token with AutoDetect, Left, Right values
    - Query based conditional load of CC files using config token
    - Added json based patches for correcting warp and surrounding tiles